### PR TITLE
feat: add clickhouse v24.7, v24.8, v24.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -214,7 +214,10 @@ jobs:
     strategy:
       matrix:
         tags:
+          - clickhouse_24.9
+          - clickhouse_24.7
           - clickhouse_24.6
+          - clickhouse_24.8
           - clickhouse_24.3
           - clickhouse_24.5
     env:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ python3 gen.py
     - [`ghcr.io/duyet/docker-images:sccache-scheduler`](#rustsccache-scheduler)
     - [`ghcr.io/duyet/docker-images:athena`](#rustathena)
 - [`clickhouse-server`](#clickhouse-server)
+    - [`ghcr.io/duyet/docker-images:clickhouse_24.9`](#clickhouse-serverclickhouse_249)
+    - [`ghcr.io/duyet/docker-images:clickhouse_24.7`](#clickhouse-serverclickhouse_247)
     - [`ghcr.io/duyet/docker-images:clickhouse_24.6`](#clickhouse-serverclickhouse_246)
+    - [`ghcr.io/duyet/docker-images:clickhouse_24.8`](#clickhouse-serverclickhouse_248)
     - [`ghcr.io/duyet/docker-images:clickhouse_24.3`](#clickhouse-serverclickhouse_243)
     - [`ghcr.io/duyet/docker-images:clickhouse_24.5`](#clickhouse-serverclickhouse_245)
 - [`kubeconform`](#kubeconform)
@@ -225,6 +228,36 @@ FROM ghcr.io/duyet/docker-images:athena
 
 ## `clickhouse-server`
 
+### [`clickhouse-server/clickhouse_24.9`](clickhouse-server/clickhouse_24.9/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.9
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.9
+```
+
+
+### [`clickhouse-server/clickhouse_24.7`](clickhouse-server/clickhouse_24.7/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.7
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.7
+```
+
+
 ### [`clickhouse-server/clickhouse_24.6`](clickhouse-server/clickhouse_24.6/Dockerfile)
 
 Install from the command line
@@ -237,6 +270,21 @@ Use as base image in Dockerfile:
 
 ```Dockerfile
 FROM ghcr.io/duyet/docker-images:clickhouse_24.6
+```
+
+
+### [`clickhouse-server/clickhouse_24.8`](clickhouse-server/clickhouse_24.8/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_24.8
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_24.8
 ```
 
 

--- a/clickhouse-server/clickhouse_24.7/Dockerfile
+++ b/clickhouse-server/clickhouse_24.7/Dockerfile
@@ -1,0 +1,4 @@
+FROM clickhouse/clickhouse-server:24.7
+
+COPY clickhouse-server/clickhouse_24.7/config.d/ /etc/clickhouse-server/config.d/
+COPY clickhouse-server/clickhouse_24.7/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/

--- a/clickhouse-server/clickhouse_24.7/config.d/setting_log-preprocessed.xml
+++ b/clickhouse-server/clickhouse_24.7/config.d/setting_log-preprocessed.xml
@@ -1,0 +1,21 @@
+<!-- This file was generated automatically.
+     Do not edit it: it is likely to be discarded and generated again before it's read next time.
+     Files used to generate this file:
+       config.d/setting_log.xml      -->
+
+<yandex>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </part_log>
+</yandex>

--- a/clickhouse-server/clickhouse_24.7/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_24.7/config.d/setting_log.xml
@@ -1,0 +1,16 @@
+<yandex>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </part_log>
+</yandex>

--- a/clickhouse-server/clickhouse_24.7/docker-entrypoint-initdb.d/init-db.sh
+++ b/clickhouse-server/clickhouse_24.7/docker-entrypoint-initdb.d/init-db.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+clickhouse client -n <<-EOSQL
+    CREATE DATABASE data_lake;
+
+    CREATE TABLE data_lake.events (
+      event_name LowCardinality(String),
+      event_value String,
+      event_time DateTime DEFAULT now()
+    ) ENGINE = MergeTree
+    ORDER BY event_time;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+EOSQL

--- a/clickhouse-server/clickhouse_24.8/Dockerfile
+++ b/clickhouse-server/clickhouse_24.8/Dockerfile
@@ -1,0 +1,4 @@
+FROM clickhouse/clickhouse-server:24.8
+
+COPY clickhouse-server/clickhouse_24.8/config.d/ /etc/clickhouse-server/config.d/
+COPY clickhouse-server/clickhouse_24.8/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/

--- a/clickhouse-server/clickhouse_24.8/config.d/setting_log-preprocessed.xml
+++ b/clickhouse-server/clickhouse_24.8/config.d/setting_log-preprocessed.xml
@@ -1,0 +1,21 @@
+<!-- This file was generated automatically.
+     Do not edit it: it is likely to be discarded and generated again before it's read next time.
+     Files used to generate this file:
+       config.d/setting_log.xml      -->
+
+<yandex>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </part_log>
+</yandex>

--- a/clickhouse-server/clickhouse_24.8/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_24.8/config.d/setting_log.xml
@@ -1,0 +1,16 @@
+<yandex>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </part_log>
+</yandex>

--- a/clickhouse-server/clickhouse_24.8/docker-entrypoint-initdb.d/init-db.sh
+++ b/clickhouse-server/clickhouse_24.8/docker-entrypoint-initdb.d/init-db.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+clickhouse client -n <<-EOSQL
+    CREATE DATABASE data_lake;
+
+    CREATE TABLE data_lake.events (
+      event_name LowCardinality(String),
+      event_value String,
+      event_time DateTime DEFAULT now()
+    ) ENGINE = MergeTree
+    ORDER BY event_time;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+EOSQL

--- a/clickhouse-server/clickhouse_24.9/Dockerfile
+++ b/clickhouse-server/clickhouse_24.9/Dockerfile
@@ -1,0 +1,4 @@
+FROM clickhouse/clickhouse-server:head
+
+COPY clickhouse-server/clickhouse_24.9/config.d/ /etc/clickhouse-server/config.d/
+COPY clickhouse-server/clickhouse_24.9/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/

--- a/clickhouse-server/clickhouse_24.9/config.d/setting_log-preprocessed.xml
+++ b/clickhouse-server/clickhouse_24.9/config.d/setting_log-preprocessed.xml
@@ -1,0 +1,21 @@
+<!-- This file was generated automatically.
+     Do not edit it: it is likely to be discarded and generated again before it's read next time.
+     Files used to generate this file:
+       config.d/setting_log.xml      -->
+
+<yandex>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </part_log>
+</yandex>

--- a/clickhouse-server/clickhouse_24.9/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_24.9/config.d/setting_log.xml
@@ -1,0 +1,16 @@
+<yandex>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </part_log>
+</yandex>

--- a/clickhouse-server/clickhouse_24.9/docker-entrypoint-initdb.d/init-db.sh
+++ b/clickhouse-server/clickhouse_24.9/docker-entrypoint-initdb.d/init-db.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+clickhouse client -n <<-EOSQL
+    CREATE DATABASE data_lake;
+
+    CREATE TABLE data_lake.events (
+      event_name LowCardinality(String),
+      event_value String,
+      event_time DateTime DEFAULT now()
+    ) ENGINE = MergeTree
+    ORDER BY event_time;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+EOSQL


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce Docker images for ClickHouse versions 24.7, 24.8, and 24.9, update CI configuration to test these versions, and update documentation to reflect these additions.

New Features:
- Add Docker images for ClickHouse versions 24.7, 24.8, and 24.9, including instructions for pulling and using these images as base images in Dockerfiles.

CI:
- Update CI workflow to include testing for ClickHouse versions 24.7, 24.8, and 24.9.

Documentation:
- Update README.md to document the availability and usage of ClickHouse Docker images for versions 24.7, 24.8, and 24.9.

<!-- Generated by sourcery-ai[bot]: end summary -->