### PR TITLE
chore(clickhouse): add keeper settings and config error_log table

### DIFF
--- a/clickhouse-server/clickhouse_24.3/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.3/config.d/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.3/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_24.3/config.d/setting_log.xml
@@ -1,4 +1,4 @@
-<yandex>
+<clickhouse>
   <profiles>
     <log_queries>1</log_queries>
   </profiles>
@@ -13,4 +13,15 @@
     <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
     <flush_on_crash>false</flush_on_crash>
   </part_log>
-</yandex>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.5/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.5/config.d/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.5/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_24.5/config.d/setting_log.xml
@@ -1,4 +1,4 @@
-<yandex>
+<clickhouse>
   <profiles>
     <log_queries>1</log_queries>
   </profiles>
@@ -13,4 +13,15 @@
     <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
     <flush_on_crash>false</flush_on_crash>
   </part_log>
-</yandex>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.6/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.6/config.d/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.6/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_24.6/config.d/setting_log.xml
@@ -1,4 +1,4 @@
-<yandex>
+<clickhouse>
   <profiles>
     <log_queries>1</log_queries>
   </profiles>
@@ -13,4 +13,15 @@
     <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
     <flush_on_crash>false</flush_on_crash>
   </part_log>
-</yandex>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.7/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.7/config.d/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.7/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_24.7/config.d/setting_log.xml
@@ -1,4 +1,4 @@
-<yandex>
+<clickhouse>
   <profiles>
     <log_queries>1</log_queries>
   </profiles>
@@ -13,4 +13,15 @@
     <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
     <flush_on_crash>false</flush_on_crash>
   </part_log>
-</yandex>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.8/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.8/config.d/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.8/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_24.8/config.d/setting_log.xml
@@ -1,4 +1,4 @@
-<yandex>
+<clickhouse>
   <profiles>
     <log_queries>1</log_queries>
   </profiles>
@@ -13,4 +13,15 @@
     <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
     <flush_on_crash>false</flush_on_crash>
   </part_log>
-</yandex>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.9/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.9/config.d/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.9/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_24.9/config.d/setting_log.xml
@@ -1,4 +1,4 @@
-<yandex>
+<clickhouse>
   <profiles>
     <log_queries>1</log_queries>
   </profiles>
@@ -13,4 +13,15 @@
     <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
     <flush_on_crash>false</flush_on_crash>
   </part_log>
-</yandex>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <collect_interval_milliseconds>1000</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>false</flush_on_crash>
+  </error_log>
+</clickhouse>


### PR DESCRIPTION
## Summary by Sourcery

Add keeper settings and error_log table configuration to ClickHouse XML files, and update XML tags for consistency.

Enhancements:
- Add error_log configuration to ClickHouse settings for improved error tracking.

Chores:
- Update XML configuration files to replace <yandex> tags with <clickhouse> tags for consistency.