### PR TITLE
feat(clickhouse): add keeper config

### DIFF
--- a/clickhouse-server/clickhouse_24.10/Dockerfile
+++ b/clickhouse-server/clickhouse_24.10/Dockerfile
@@ -2,3 +2,4 @@ FROM clickhouse/clickhouse-server:head
 
 COPY clickhouse-server/clickhouse_24.10/config.d/ /etc/clickhouse-server/config.d/
 COPY clickhouse-server/clickhouse_24.10/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY clickhouse-server/clickhouse_24.10/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_24.10/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.10/config.d/keeper.xml
@@ -5,25 +5,4 @@
 			<port>9181</port>
 		</node>
 	</zookeeper>
-
-    <keeper_server>
-        <tcp_port>2181</tcp_port>
-        <server_id>1</server_id>
-        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
-        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
-
-        <coordination_settings>
-            <operation_timeout_ms>10000</operation_timeout_ms>
-            <session_timeout_ms>30000</session_timeout_ms>
-            <raft_logs_level>trace</raft_logs_level>
-        </coordination_settings>
-
-        <raft_configuration>
-            <server>
-                <id>1</id>
-                <hostname>localhost</hostname>
-                <port>9234</port>
-            </server>
-        </raft_configuration>
-    </keeper_server>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.10/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_24.10/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_24.10/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_24.10/keeper/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.3/Dockerfile
+++ b/clickhouse-server/clickhouse_24.3/Dockerfile
@@ -2,3 +2,4 @@ FROM clickhouse/clickhouse-server:24.3
 
 COPY clickhouse-server/clickhouse_24.3/config.d/ /etc/clickhouse-server/config.d/
 COPY clickhouse-server/clickhouse_24.3/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY clickhouse-server/clickhouse_24.3/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_24.3/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.3/config.d/keeper.xml
@@ -5,25 +5,4 @@
 			<port>9181</port>
 		</node>
 	</zookeeper>
-
-    <keeper_server>
-        <tcp_port>2181</tcp_port>
-        <server_id>1</server_id>
-        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
-        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
-
-        <coordination_settings>
-            <operation_timeout_ms>10000</operation_timeout_ms>
-            <session_timeout_ms>30000</session_timeout_ms>
-            <raft_logs_level>trace</raft_logs_level>
-        </coordination_settings>
-
-        <raft_configuration>
-            <server>
-                <id>1</id>
-                <hostname>localhost</hostname>
-                <port>9234</port>
-            </server>
-        </raft_configuration>
-    </keeper_server>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.3/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_24.3/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_24.3/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_24.3/keeper/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.5/Dockerfile
+++ b/clickhouse-server/clickhouse_24.5/Dockerfile
@@ -2,3 +2,4 @@ FROM clickhouse/clickhouse-server:24.5
 
 COPY clickhouse-server/clickhouse_24.5/config.d/ /etc/clickhouse-server/config.d/
 COPY clickhouse-server/clickhouse_24.5/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY clickhouse-server/clickhouse_24.5/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_24.5/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.5/config.d/keeper.xml
@@ -5,25 +5,4 @@
 			<port>9181</port>
 		</node>
 	</zookeeper>
-
-    <keeper_server>
-        <tcp_port>2181</tcp_port>
-        <server_id>1</server_id>
-        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
-        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
-
-        <coordination_settings>
-            <operation_timeout_ms>10000</operation_timeout_ms>
-            <session_timeout_ms>30000</session_timeout_ms>
-            <raft_logs_level>trace</raft_logs_level>
-        </coordination_settings>
-
-        <raft_configuration>
-            <server>
-                <id>1</id>
-                <hostname>localhost</hostname>
-                <port>9234</port>
-            </server>
-        </raft_configuration>
-    </keeper_server>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.5/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_24.5/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_24.5/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_24.5/keeper/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.6/Dockerfile
+++ b/clickhouse-server/clickhouse_24.6/Dockerfile
@@ -2,3 +2,4 @@ FROM clickhouse/clickhouse-server:24.6
 
 COPY clickhouse-server/clickhouse_24.6/config.d/ /etc/clickhouse-server/config.d/
 COPY clickhouse-server/clickhouse_24.6/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY clickhouse-server/clickhouse_24.6/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_24.6/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.6/config.d/keeper.xml
@@ -5,25 +5,4 @@
 			<port>9181</port>
 		</node>
 	</zookeeper>
-
-    <keeper_server>
-        <tcp_port>2181</tcp_port>
-        <server_id>1</server_id>
-        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
-        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
-
-        <coordination_settings>
-            <operation_timeout_ms>10000</operation_timeout_ms>
-            <session_timeout_ms>30000</session_timeout_ms>
-            <raft_logs_level>trace</raft_logs_level>
-        </coordination_settings>
-
-        <raft_configuration>
-            <server>
-                <id>1</id>
-                <hostname>localhost</hostname>
-                <port>9234</port>
-            </server>
-        </raft_configuration>
-    </keeper_server>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.6/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_24.6/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_24.6/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_24.6/keeper/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.7/Dockerfile
+++ b/clickhouse-server/clickhouse_24.7/Dockerfile
@@ -2,3 +2,4 @@ FROM clickhouse/clickhouse-server:24.7
 
 COPY clickhouse-server/clickhouse_24.7/config.d/ /etc/clickhouse-server/config.d/
 COPY clickhouse-server/clickhouse_24.7/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY clickhouse-server/clickhouse_24.7/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_24.7/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.7/config.d/keeper.xml
@@ -5,25 +5,4 @@
 			<port>9181</port>
 		</node>
 	</zookeeper>
-
-    <keeper_server>
-        <tcp_port>2181</tcp_port>
-        <server_id>1</server_id>
-        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
-        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
-
-        <coordination_settings>
-            <operation_timeout_ms>10000</operation_timeout_ms>
-            <session_timeout_ms>30000</session_timeout_ms>
-            <raft_logs_level>trace</raft_logs_level>
-        </coordination_settings>
-
-        <raft_configuration>
-            <server>
-                <id>1</id>
-                <hostname>localhost</hostname>
-                <port>9234</port>
-            </server>
-        </raft_configuration>
-    </keeper_server>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.7/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_24.7/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_24.7/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_24.7/keeper/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.8/Dockerfile
+++ b/clickhouse-server/clickhouse_24.8/Dockerfile
@@ -2,3 +2,4 @@ FROM clickhouse/clickhouse-server:24.8
 
 COPY clickhouse-server/clickhouse_24.8/config.d/ /etc/clickhouse-server/config.d/
 COPY clickhouse-server/clickhouse_24.8/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY clickhouse-server/clickhouse_24.8/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_24.8/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.8/config.d/keeper.xml
@@ -5,25 +5,4 @@
 			<port>9181</port>
 		</node>
 	</zookeeper>
-
-    <keeper_server>
-        <tcp_port>2181</tcp_port>
-        <server_id>1</server_id>
-        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
-        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
-
-        <coordination_settings>
-            <operation_timeout_ms>10000</operation_timeout_ms>
-            <session_timeout_ms>30000</session_timeout_ms>
-            <raft_logs_level>trace</raft_logs_level>
-        </coordination_settings>
-
-        <raft_configuration>
-            <server>
-                <id>1</id>
-                <hostname>localhost</hostname>
-                <port>9234</port>
-            </server>
-        </raft_configuration>
-    </keeper_server>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.8/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_24.8/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_24.8/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_24.8/keeper/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_24.9/Dockerfile
+++ b/clickhouse-server/clickhouse_24.9/Dockerfile
@@ -2,3 +2,4 @@ FROM clickhouse/clickhouse-server:head
 
 COPY clickhouse-server/clickhouse_24.9/config.d/ /etc/clickhouse-server/config.d/
 COPY clickhouse-server/clickhouse_24.9/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY clickhouse-server/clickhouse_24.9/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_24.9/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.9/config.d/keeper.xml
@@ -5,25 +5,4 @@
 			<port>9181</port>
 		</node>
 	</zookeeper>
-
-    <keeper_server>
-        <tcp_port>2181</tcp_port>
-        <server_id>1</server_id>
-        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
-        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
-
-        <coordination_settings>
-            <operation_timeout_ms>10000</operation_timeout_ms>
-            <session_timeout_ms>30000</session_timeout_ms>
-            <raft_logs_level>trace</raft_logs_level>
-        </coordination_settings>
-
-        <raft_configuration>
-            <server>
-                <id>1</id>
-                <hostname>localhost</hostname>
-                <port>9234</port>
-            </server>
-        </raft_configuration>
-    </keeper_server>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.9/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_24.9/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_24.9/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_24.9/keeper/keeper.xml
@@ -1,0 +1,22 @@
+<clickhouse>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>


### PR DESCRIPTION
## Summary by Sourcery

Add ClickHouse Keeper configuration and entrypoint script to support coordination and raft settings across multiple ClickHouse versions.

New Features:
- Introduce a new configuration for ClickHouse Keeper across multiple versions, enabling coordination settings and raft configuration.

Enhancements:
- Add a new entrypoint script for ClickHouse Keeper to initialize with the specified configuration.