### PR TITLE
feat(clickhouse): config keeper.xml

### DIFF
--- a/clickhouse-server/clickhouse_24.10/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.10/config.d/keeper.xml
@@ -1,8 +1,8 @@
 <clickhouse>
 	<zookeeper>
 		<node>
-			<host>localhost</host>
-			<port>9181</port>
+			<host>keeper</host>
+			<port>2181</port>
 		</node>
 	</zookeeper>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.3/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.3/config.d/keeper.xml
@@ -1,8 +1,8 @@
 <clickhouse>
 	<zookeeper>
 		<node>
-			<host>localhost</host>
-			<port>9181</port>
+			<host>keeper</host>
+			<port>2181</port>
 		</node>
 	</zookeeper>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.5/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.5/config.d/keeper.xml
@@ -1,8 +1,8 @@
 <clickhouse>
 	<zookeeper>
 		<node>
-			<host>localhost</host>
-			<port>9181</port>
+			<host>keeper</host>
+			<port>2181</port>
 		</node>
 	</zookeeper>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.6/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.6/config.d/keeper.xml
@@ -1,8 +1,8 @@
 <clickhouse>
 	<zookeeper>
 		<node>
-			<host>localhost</host>
-			<port>9181</port>
+			<host>keeper</host>
+			<port>2181</port>
 		</node>
 	</zookeeper>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.7/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.7/config.d/keeper.xml
@@ -1,8 +1,8 @@
 <clickhouse>
 	<zookeeper>
 		<node>
-			<host>localhost</host>
-			<port>9181</port>
+			<host>keeper</host>
+			<port>2181</port>
 		</node>
 	</zookeeper>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.8/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.8/config.d/keeper.xml
@@ -1,8 +1,8 @@
 <clickhouse>
 	<zookeeper>
 		<node>
-			<host>localhost</host>
-			<port>9181</port>
+			<host>keeper</host>
+			<port>2181</port>
 		</node>
 	</zookeeper>
 </clickhouse>

--- a/clickhouse-server/clickhouse_24.9/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_24.9/config.d/keeper.xml
@@ -1,8 +1,8 @@
 <clickhouse>
 	<zookeeper>
 		<node>
-			<host>localhost</host>
-			<port>9181</port>
+			<host>keeper</host>
+			<port>2181</port>
 		</node>
 	</zookeeper>
 </clickhouse>


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update the ClickHouse configuration to use 'keeper' as the host and '2181' as the port for the ZooKeeper node across multiple versions.