### PR TITLE
feat: add ClickHouse v25.7 and v25.8 images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -419,7 +419,9 @@ jobs:
           - clickhouse_24.7
           - clickhouse_24.6
           - clickhouse_24.8
+          - clickhouse_25.7
           - clickhouse_24.12
+          - clickhouse_25.8
           - clickhouse_25.1
           - clickhouse_25.6
           - clickhouse_24.3

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ python3 gen.py
     - [`ghcr.io/duyet/docker-images:clickhouse_25.4`](#clickhouse-serverclickhouse_254)
     - [`ghcr.io/duyet/docker-images:clickhouse_25.5`](#clickhouse-serverclickhouse_255)
     - [`ghcr.io/duyet/docker-images:clickhouse_25.6`](#clickhouse-serverclickhouse_256)
+    - [`ghcr.io/duyet/docker-images:clickhouse_25.7`](#clickhouse-serverclickhouse_257)
+    - [`ghcr.io/duyet/docker-images:clickhouse_25.8`](#clickhouse-serverclickhouse_258)
 - [`debezium`](#debezium)
     - [`ghcr.io/duyet/docker-images:debezium_1.9.5.Final`](#debeziumdebezium_195final)
     - [`ghcr.io/duyet/docker-images:debezium_2.0.0.Beta1`](#debeziumdebezium_200beta1)
@@ -543,6 +545,21 @@ FROM ghcr.io/duyet/docker-images:clickhouse_24.8
 ```
 
 
+### [`clickhouse-server/clickhouse_25.7`](clickhouse-server/clickhouse_25.7/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.7
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.7
+```
+
+
 ### [`clickhouse-server/clickhouse_24.12`](clickhouse-server/clickhouse_24.12/Dockerfile)
 
 Install from the command line
@@ -555,6 +572,21 @@ Use as base image in Dockerfile:
 
 ```Dockerfile
 FROM ghcr.io/duyet/docker-images:clickhouse_24.12
+```
+
+
+### [`clickhouse-server/clickhouse_25.8`](clickhouse-server/clickhouse_25.8/Dockerfile)
+
+Install from the command line
+
+```bash
+docker pull ghcr.io/duyet/docker-images:clickhouse_25.8
+```
+
+Use as base image in Dockerfile:
+
+```Dockerfile
+FROM ghcr.io/duyet/docker-images:clickhouse_25.8
 ```
 
 

--- a/clickhouse-server/clickhouse_25.7/Dockerfile
+++ b/clickhouse-server/clickhouse_25.7/Dockerfile
@@ -1,0 +1,5 @@
+FROM clickhouse/clickhouse-server:25.7
+
+COPY --chmod=755 clickhouse-server/clickhouse_25.7/config.d/ /etc/clickhouse-server/config.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.7/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.7/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_25.7/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_25.7/config.d/keeper.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+	<zookeeper>
+		<node>
+			<host>keeper</host>
+			<port>2181</port>
+		</node>
+	</zookeeper>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.7/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_25.7/config.d/setting_log.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </part_log>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>100</flush_interval_milliseconds>
+    <collect_interval_milliseconds>100</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>100</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.7/config.d/storage.xml
+++ b/clickhouse-server/clickhouse_25.7/config.d/storage.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <backups>
+                <type>local</type>
+                <path>/tmp/backups/</path>
+            </backups>
+        </disks>
+    </storage_configuration>
+
+    <backups>
+        <allowed_disk>backups</allowed_disk>
+        <allowed_path>/tmp/backups/</allowed_path>
+    </backups>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.7/config.d/users.xml
+++ b/clickhouse-server/clickhouse_25.7/config.d/users.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+    <users>
+        <default>
+            <password></password>
+            <access_management>1</access_management>
+            <profile>default</profile>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <grants>
+                <query>GRANT ALL ON *.*</query>
+            </grants>
+        </default>
+    </users>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.7/docker-entrypoint-initdb.d/init-db.sh
+++ b/clickhouse-server/clickhouse_25.7/docker-entrypoint-initdb.d/init-db.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+clickhouse client -n <<-EOSQL
+    CREATE DATABASE data_lake;
+
+    CREATE TABLE data_lake.events (
+      event_name LowCardinality(String),
+      event_value String,
+      event_time DateTime DEFAULT now()
+    ) ENGINE = MergeTree
+    ORDER BY event_time;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    BACKUP TABLE data_lake.events TO Disk('backups', 'init_backup.zip');
+EOSQL

--- a/clickhouse-server/clickhouse_25.7/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_25.7/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_25.7/keeper/healthcheck.sh
+++ b/clickhouse-server/clickhouse_25.7/keeper/healthcheck.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+date && OK=$(
+    exec 3<>/dev/tcp/127.0.0.1/2181
+    printf "ruok" >&3
+    IFS=
+    tee <&3
+    exec 3<&-
+)
+
+if [[ "$OK" == "imok" ]]; then
+    exit 0
+else
+    exit 1
+fi

--- a/clickhouse-server/clickhouse_25.7/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_25.7/keeper/keeper.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <four_letter_word_white_list>*</four_letter_word_white_list>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.8/Dockerfile
+++ b/clickhouse-server/clickhouse_25.8/Dockerfile
@@ -1,0 +1,5 @@
+FROM clickhouse/clickhouse-server:25.8
+
+COPY --chmod=755 clickhouse-server/clickhouse_25.8/config.d/ /etc/clickhouse-server/config.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.8/docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+COPY --chmod=755 clickhouse-server/clickhouse_25.8/keeper/ /keeper/

--- a/clickhouse-server/clickhouse_25.8/config.d/keeper.xml
+++ b/clickhouse-server/clickhouse_25.8/config.d/keeper.xml
@@ -1,0 +1,8 @@
+<clickhouse>
+	<zookeeper>
+		<node>
+			<host>keeper</host>
+			<port>2181</port>
+		</node>
+	</zookeeper>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.8/config.d/setting_log.xml
+++ b/clickhouse-server/clickhouse_25.8/config.d/setting_log.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+  <profiles>
+    <log_queries>1</log_queries>
+  </profiles>
+
+  <part_log>
+    <database>system</database>
+    <table>part_log</table>
+    <partition_by>toMonday(event_date)</partition_by>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>524288</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </part_log>
+
+  <error_log>
+    <database>system</database>
+    <table>error_log</table>
+    <flush_interval_milliseconds>100</flush_interval_milliseconds>
+    <collect_interval_milliseconds>100</collect_interval_milliseconds>
+    <max_size_rows>1048576</max_size_rows>
+    <reserved_size_rows>8192</reserved_size_rows>
+    <buffer_size_rows_flush_threshold>100</buffer_size_rows_flush_threshold>
+    <flush_on_crash>true</flush_on_crash>
+  </error_log>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.8/config.d/storage.xml
+++ b/clickhouse-server/clickhouse_25.8/config.d/storage.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <backups>
+                <type>local</type>
+                <path>/tmp/backups/</path>
+            </backups>
+        </disks>
+    </storage_configuration>
+
+    <backups>
+        <allowed_disk>backups</allowed_disk>
+        <allowed_path>/tmp/backups/</allowed_path>
+    </backups>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.8/config.d/users.xml
+++ b/clickhouse-server/clickhouse_25.8/config.d/users.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+    <users>
+        <default>
+            <password></password>
+            <access_management>1</access_management>
+            <profile>default</profile>
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+            <grants>
+                <query>GRANT ALL ON *.*</query>
+            </grants>
+        </default>
+    </users>
+</clickhouse>

--- a/clickhouse-server/clickhouse_25.8/docker-entrypoint-initdb.d/init-db.sh
+++ b/clickhouse-server/clickhouse_25.8/docker-entrypoint-initdb.d/init-db.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+clickhouse client -n <<-EOSQL
+    CREATE DATABASE data_lake;
+
+    CREATE TABLE data_lake.events (
+      event_name LowCardinality(String),
+      event_value String,
+      event_time DateTime DEFAULT now()
+    ) ENGINE = MergeTree
+    ORDER BY event_time;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    INSERT INTO data_lake.events (event_name, event_value)
+    SELECT * FROM generateRandom('event_name LowCardinality(String), event_value String') LIMIT 100;
+
+    BACKUP TABLE data_lake.events TO Disk('backups', 'init_backup.zip');
+EOSQL

--- a/clickhouse-server/clickhouse_25.8/keeper/entrypoint.sh
+++ b/clickhouse-server/clickhouse_25.8/keeper/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+clickhouse-keeper --config /keeper/keeper.xml

--- a/clickhouse-server/clickhouse_25.8/keeper/healthcheck.sh
+++ b/clickhouse-server/clickhouse_25.8/keeper/healthcheck.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+date && OK=$(
+    exec 3<>/dev/tcp/127.0.0.1/2181
+    printf "ruok" >&3
+    IFS=
+    tee <&3
+    exec 3<&-
+)
+
+if [[ "$OK" == "imok" ]]; then
+    exit 0
+else
+    exit 1
+fi

--- a/clickhouse-server/clickhouse_25.8/keeper/keeper.xml
+++ b/clickhouse-server/clickhouse_25.8/keeper/keeper.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <listen_host>0.0.0.0</listen_host>
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <four_letter_word_white_list>*</four_letter_word_white_list>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>


### PR DESCRIPTION
## Summary
- Add ClickHouse server images for versions 25.7 and 25.8
- Copy configuration from v25.6 baseline for consistency
- Regenerate CI workflows and README documentation to include new images

## Test plan
- [ ] CI workflows build both new images successfully
- [ ] Images are published to GitHub Container Registry
- [ ] Multi-architecture builds (linux/amd64, linux/arm64) work correctly
- [ ] Configuration files are properly copied and permissions set correctly